### PR TITLE
[Codex] fix(out): 公式に静的 /out ページを追加して 404 解消

### DIFF
--- a/out/apple-artist/index.html
+++ b/out/apple-artist/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>リダイレクト中...</title>
+    <meta name="robots" content="noindex, nofollow" />
+    <script>
+      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+      window.REDIRECT_TO = 'https://music.apple.com/jp/artist/%E3%82%A2%E3%83%83%E3%83%97%E3%83%AA%E3%83%90%E3%83%BC/1816403477';
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+  </head>
+  <body>
+    <script>location.replace(window.REDIRECT_TO);</script>
+  </body>
+  </html>
+

--- a/out/apple-music/index.html
+++ b/out/apple-music/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>リダイレクト中...</title>
+    <meta name="robots" content="noindex, nofollow" />
+    <script>
+      window.va = window.va || function () {
+        (window.vaq = window.vaq || []).push(arguments);
+      };
+      window.REDIRECT_TO = 'https://music.apple.com/jp/playlist/appriver-%E5%85%AC%E5%BC%8F%E3%83%97%E3%83%AC%E3%82%A4%E3%83%AA%E3%82%B9%E3%83%88/pl.u-V9D7vD9FEP64AZ';
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+  </head>
+  <body>
+    <script>location.replace(window.REDIRECT_TO);</script>
+  </body>
+  </html>
+

--- a/out/index.html
+++ b/out/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>リダイレクト中...</title>
+    <meta http-equiv="refresh" content="5" />
+    <meta name="robots" content="noindex, nofollow" />
+
+    <script>
+      // Vercel Analytics: pageview を送るためのローダ
+      window.va = window.va || function () {
+        (window.vaq = window.vaq || []).push(arguments);
+      };
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+
+    <style>
+      body { font-family: system-ui, -apple-system, Segoe UI, Roboto, 'Noto Sans JP', Arial, sans-serif; margin: 0; padding: 2rem; color: #333; }
+      .box { max-width: 560px; margin: 10vh auto 0; border: 1px solid #eee; border-radius: 12px; padding: 1.5rem; box-shadow: 0 6px 24px rgba(0, 0, 0, 0.06); }
+      .title { margin: 0 0 0.25rem; font-size: 1.25rem; font-weight: 600; }
+      .url { word-break: break-all; color: #666; font-size: 0.9rem; }
+      .hint { margin-top: 0.75rem; color: #666; font-size: 0.9rem; }
+      .link { display: inline-block; margin-top: 1rem; color: #0b6bcb; text-decoration: none; }
+    </style>
+  </head>
+  <body>
+    <div class="box">
+      <div class="title">外部サイトへ移動します</div>
+      <div class="url" id="dest">読み込み中...</div>
+      <div class="hint">自動で切り替わらない場合は以下をクリックしてください。</div>
+      <a class="link" id="link" href="#" rel="nofollow noopener">今すぐ移動</a>
+    </div>
+
+    <script>
+      (function () {
+        var params = new URLSearchParams(location.search);
+        var to = window.REDIRECT_TO || params.get('to');
+        try { if (to) to = decodeURIComponent(to); } catch (_) {}
+        var linkEl = document.getElementById('link');
+        var destEl = document.getElementById('dest');
+        if (to) { linkEl.href = to; destEl.textContent = to; } else { destEl.textContent = 'リンク先URLが見つかりませんでした。'; }
+        window.addEventListener('load', function () { setTimeout(function () { if (to) location.replace(to); }, 300); });
+      })();
+    </script>
+  </body>
+  </html>
+

--- a/out/karaoke-coupon/index.html
+++ b/out/karaoke-coupon/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>リダイレクト中...</title>
+    <meta name="robots" content="noindex, nofollow" />
+    <script>
+      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+      window.REDIRECT_TO = 'https://social.kicks.video/v1/re/kr/82108/joysound_coupon?utm_source=vk&utm_medium=sw&utm_campaign=share&utm_term=82108';
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+  </head>
+  <body>
+    <script>location.replace(window.REDIRECT_TO);</script>
+  </body>
+  </html>
+

--- a/out/nukumori/index.html
+++ b/out/nukumori/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>リダイレクト中...</title>
+    <meta name="robots" content="noindex, nofollow" />
+    <script>
+      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+      window.REDIRECT_TO = 'https://linkco.re/E7hxe2Ay';
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+  </head>
+  <body>
+    <script>location.replace(window.REDIRECT_TO);</script>
+  </body>
+  </html>
+

--- a/out/others/index.html
+++ b/out/others/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>リダイレクト中...</title>
+    <meta name="robots" content="noindex, nofollow" />
+    <script>
+      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+      window.REDIRECT_TO = 'https://www.tunecore.co.jp/artists?id=991248';
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+  </head>
+  <body>
+    <script>location.replace(window.REDIRECT_TO);</script>
+  </body>
+  </html>
+

--- a/out/spotify-artist/index.html
+++ b/out/spotify-artist/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>リダイレクト中...</title>
+    <meta name="robots" content="noindex, nofollow" />
+    <script>
+      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+      window.REDIRECT_TO = 'https://open.spotify.com/intl-ja/artist/2PbgbV4vBCzAUV9ZfHPG3Z';
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+  </head>
+  <body>
+    <script>location.replace(window.REDIRECT_TO);</script>
+  </body>
+  </html>
+

--- a/out/spotify/index.html
+++ b/out/spotify/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>リダイレクト中...</title>
+    <meta name="robots" content="noindex, nofollow" />
+    <script>
+      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+      window.REDIRECT_TO = 'https://open.spotify.com/playlist/1Y4ICAnET0o7CPHRycOriz';
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+  </head>
+  <body>
+    <script>location.replace(window.REDIRECT_TO);</script>
+  </body>
+  </html>
+

--- a/out/tiktok/index.html
+++ b/out/tiktok/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>リダイレクト中...</title>
+    <meta name="robots" content="noindex, nofollow" />
+    <script>
+      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+      window.REDIRECT_TO = 'https://www.tiktok.com/@appriver?is_from_webapp=1&sender_device=pc';
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+  </head>
+  <body>
+    <script>location.replace(window.REDIRECT_TO);</script>
+  </body>
+  </html>
+

--- a/out/tiktok2/index.html
+++ b/out/tiktok2/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>リダイレクト中...</title>
+    <meta name="robots" content="noindex, nofollow" />
+    <script>
+      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+      window.REDIRECT_TO = 'https://www.tiktok.com/@appriver12?is_from_webapp=1&sender_device=pc';
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+  </head>
+  <body>
+    <script>location.replace(window.REDIRECT_TO);</script>
+  </body>
+  </html>
+

--- a/out/yasuragi/index.html
+++ b/out/yasuragi/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>リダイレクト中...</title>
+    <meta name="robots" content="noindex, nofollow" />
+    <script>
+      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+      window.REDIRECT_TO = 'https://linkco.re/1gXERgmA';
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+  </head>
+  <body>
+    <script>location.replace(window.REDIRECT_TO);</script>
+  </body>
+  </html>
+

--- a/out/youtube/index.html
+++ b/out/youtube/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>リダイレクト中...</title>
+    <meta name="robots" content="noindex, nofollow" />
+    <script>
+      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+      window.REDIRECT_TO = 'https://www.youtube.com/@appriver12';
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+  </head>
+  <body>
+    <script>location.replace(window.REDIRECT_TO);</script>
+  </body>
+  </html>
+


### PR DESCRIPTION
現象\n- /out/* へのリンクが 404: NOT_FOUND（songs&lyrics 以外が落ちる）\n\n原因\n- 公式サイトの配信環境が Vercel rewrites 非対応/未適用で、物理ファイルの無い /out/* が 404 になっていた\n\n対応\n- out/<slug>/index.html を追加（Apple/Spotify/YouTube/Others/Artist/TikTok/アルバム/クーポン）\n- out/index.html は共通ロジック（REDIRECT_TO または ?to= を解釈）\n- これにより Vercel/GitHub Pages いずれでも 200→外部遷移になり、Hobbyでも /out のPV計測が可能\n\n影響\n- 既存の index.html 内の /out/* リンクはそのままでOK\n- AnalyticsのカスタムイベントはHobbyでは非保存だが無害（Pro移行で即可視化）