### PR TITLE
[Codex] hero: カラオケクーポンのREDIRECT_TOをUTM付83855へ更新（公式）

### DIFF
--- a/out/karaoke-coupon/index.html
+++ b/out/karaoke-coupon/index.html
@@ -7,7 +7,7 @@
     <meta name="robots" content="noindex, nofollow" />
     <script>
       window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
-      window.REDIRECT_TO = 'https://social.kicks.video/v1/re/kr/82108/joysound_coupon?utm_source=vk&utm_medium=sw&utm_campaign=share&utm_term=82108';
+      window.REDIRECT_TO = 'https://social.kicks.video/v1/re/kr/83855/joysound_coupon?utm_source=vk&utm_medium=sw&utm_campaign=share&utm_term=83855';
     </script>
     <script defer src="/_vercel/insights/script.js"></script>
   </head>
@@ -15,4 +15,3 @@
     <script>location.replace(window.REDIRECT_TO);</script>
   </body>
   </html>
-


### PR DESCRIPTION
- out/karaoke-coupon/index.html の REDIRECT_TO を UTM付URL（83855）に更新\n- 公式サイトは rewrites が無効/未適用のケースがあるため、静的ページ側のURLが実体\n- マージ後はスマホから正しくUTM付きリンクへ遷移します