### PR TITLE
[promote] Amazonアーティスト直リンク＋モバイル最適化

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
                             </div>
 
                             <div class="amazon-artist-link">
-                                <a href="https://music.amazon.co.jp/artists/B0F9TGK1JY/%E3%82%A2%E3%83%83%E3%83%97%E3%83%AA%E3%83%90%E3%83%BC" class="amazon-artist-btn" rel="nofollow noopener">
+                                <a href="https://music.amazon.co.jp/artists/B0F9TGK1JY/%E3%82%A2%E3%83%83%E3%83%97%E3%83%AA%E3%83%90%E3%83%BC" class="amazon-artist-btn others-full-playlist-btn" rel="nofollow noopener">
                                     <i class="fas fa-external-link-alt"></i>
                                     <span>アーティストを開く</span>
                                 </a>


### PR DESCRIPTION
本PRは dev 反映済みのAmazonプレイヤー更新の昇格です。\n\n変更点\n- index.html: Amazonをアーティスト直リンク化（同一タブ遷移）\n- style.css: Amazonボタンのモバイル最適化（他プレイヤーと同一寸法）\n- music-players.js: Amazon停止ログをdirect link modeに統一、全停止へ追加\n\n確認事項\n- スマホでMUSIC PLAYERS→Amazon→『アーティストを開く』が他と同一サイズで表示\n- 遷移後、ブラウザ戻るで復帰可能\n\nマージ後、Vercel Productionデプロイで反映されます。