### PR TITLE
[Claude] feat: dヒッツ導線をリンク化

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
                     <p><i class="fas fa-info-circle"></i> 公開中の全曲のフル再生・同期歌詞・<br>うたごえモードに対応。<br>初回30日間無料(カード登録不要)です</p>
                 </div>
                 <div class="player-note">
-                    <p><i class="fas fa-info-circle"></i> ダウンロード購入は<a href="https://recochoku.jp/artist/2003671393" target="_blank" rel="noopener">レコチョク</a>でも可能です。<br>dヒッツでも配信中<br>(アプリ内で「アップリバー」を検索)</p>
+                    <p><i class="fas fa-info-circle"></i> ダウンロード購入は<a href="https://recochoku.jp/artist/2003671393" target="_blank" rel="noopener">レコチョク</a>でも可能です。<br><a href="https://dhits.docomo.ne.jp/artist/2003671393" target="_blank" rel="noopener">dヒッツ</a>でも配信中です</p>
                 </div>
             </div>
         </section>
@@ -391,6 +391,11 @@
                         class="social-link recochoku">
                         <i class="fas fa-download"></i>
                         レコチョク
+                    </a>
+                    <a href="https://dhits.docomo.ne.jp/artist/2003671393" target="_blank" rel="noopener"
+                        class="social-link dhits">
+                        <i class="fas fa-headphones"></i>
+                        dヒッツ
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
dヒッツの公開アーティストページ(ログイン不要・dhits.docomo.ne.jp/artist/2003671393)の実在を実測確認したため、テキスト案内をリンクへ格上げ。Links欄にもdヒッツを追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)