### PR TITLE
引っ張って更新が軽いタッチで誤爆する不具合を直す

### DIFF
--- a/pull-to-refresh.js
+++ b/pull-to-refresh.js
@@ -14,13 +14,18 @@
   const pullText = indicator.querySelector('.pull-text');
 
   let startY = 0;
+  let startX = 0;
   let currentY = 0;
   let pullDistance = 0;
   let isPulling = false;
   let isRefreshing = false;
+  // 指を置いた時点でページ上部にいたか。途中で判定し直すと、下までスクロールしてから
+  // 上端に戻ってきた指の動きを「巨大な引っ張り」と読み違える
+  let canPull = false;
 
   const PULL_THRESHOLD = 120; // Minimum pull distance to trigger refresh (感度を下げるために増加)
   const MAX_PULL_DISTANCE = 180; // Maximum pull distance
+  const PULL_START_SLOP = 10; // この距離までは指の震え・タップとみなして引っ張り扱いしない
 
   // Initialize
   function init() {
@@ -51,25 +56,35 @@
   function handleTouchStart(e) {
     if (isRefreshing) return;
 
-    // Only trigger if at top of page
-    if (window.pageYOffset > 0) return;
-
+    // 指を置いた位置は、ページ上部にいるかどうかに関わらず必ず記録する。
+    // ページ下部だからと記録を省くと、前のジェスチャーのstartYが残ったままになり、
+    // 上端に戻った瞬間に指の絶対位置がそのまま引っ張り量として読まれてしまう
     startY = e.touches[0].pageY;
+    startX = e.touches[0].pageX;
     isPulling = false;
+    pullDistance = 0;
+    canPull = window.pageYOffset <= 0;
   }
 
   function handleTouchMove(e) {
-    if (isRefreshing) return;
+    if (isRefreshing || !canPull) return;
 
     currentY = e.touches[0].pageY;
     const rawDistance = currentY - startY;
 
-    // Only pull down and when at top of page (10px以上のスワイプで発火させ、過敏な反応を防ぐ)
-    if (rawDistance > 10 && window.pageYOffset <= 0) {
+    // 横方向が優勢な動き(アルバムのスライダー操作など)は引っ張りとして扱わない
+    if (Math.abs(e.touches[0].pageX - startX) > Math.abs(rawDistance)) {
+      hideIndicator();
+      return;
+    }
+
+    // Only pull down and when at top of page (指の震え程度では発火させない)
+    if (rawDistance > PULL_START_SLOP && window.pageYOffset <= 0) {
       e.preventDefault(); // Prevent default scroll behavior
 
       isPulling = true;
-      pullDistance = (rawDistance - 10) * 0.6; // 0.6倍の抵抗を加えて、引っ張るのに少し力を要するようにする
+      // 0.6倍の抵抗を加えて、引っ張るのに少し力を要するようにする
+      pullDistance = (rawDistance - PULL_START_SLOP) * 0.6;
 
       // Limit pull distance
       const clampedDistance = Math.min(pullDistance, MAX_PULL_DISTANCE);
@@ -93,15 +108,18 @@
       const translateY = Math.min(clampedDistance * 0.5, 40);
       indicator.style.transform = `translateX(-50%) translateY(${translateY}px)`;
     } else {
-      resetPull();
+      // ⚠️ ここでresetPull()を呼ぶとstartYまで0に戻ってしまい、次のtouchmoveで
+      // 指の絶対位置が引っ張り量として計算される(軽いタッチでリロードが起きていた原因)。
+      // 指を離すまではstartYを保ち、見た目だけ戻す
+      hideIndicator();
     }
   }
 
   function handleTouchEnd(_e) {
-    if (!isPulling || isRefreshing) return;
+    if (isRefreshing) return;
 
     // Trigger refresh if pulled enough
-    if (pullDistance >= PULL_THRESHOLD) {
+    if (isPulling && pullDistance >= PULL_THRESHOLD) {
       triggerRefresh();
     } else {
       resetPull();
@@ -128,15 +146,23 @@
     }, 1000);
   }
 
-  function resetPull() {
+  // 見た目だけを元に戻す(指を置いた位置の記録は保つ)。ジェスチャーの途中で呼ぶのはこちら
+  function hideIndicator() {
     isPulling = false;
+    pullDistance = 0;
 
     indicator.classList.remove('visible', 'pulling', 'ready', 'refreshing');
     indicator.style.transform = 'translateX(-50%)';
     pullText.textContent = '引っ張って更新';
+  }
 
-    pullDistance = 0;
+  // ジェスチャーが終わったときの全消去。指を置いた位置の記録もここで捨てる
+  function resetPull() {
+    hideIndicator();
+
+    canPull = false;
     startY = 0;
+    startX = 0;
     currentY = 0;
   }
 


### PR DESCRIPTION
## 症状

画面上部で軽くタッチしてスクロールしようとしただけで「離すとリロード」が走る(オーナー実機)。

## 原因

ジェスチャーの**途中**で `resetPull()` を呼んでおり、そこで `startY` まで 0 に戻していた。

指を置いた直後にわずかでも上や横へぶれると(実際のタッチではほぼ必ず起きる)`rawDistance <= 10` の枝に入って `startY = 0` になる。次の `touchmove` では `rawDistance = currentY - 0` となり、**指の絶対Y座標がそのまま引っ張り量**として計算される。画面中ほどを触れば 400〜500px 引いたことになり、一瞬で「離して更新」に到達していた。

しきい値が 120 まで引き上げられていた(コメント「感度を下げるために増加」)のは、この不具合への対処だったと思われる。実距離では 210px 必要な設定になっているのに誤爆していたのは、そもそも距離計算が壊れていたため。

## 直し方

- ジェスチャー中は**見た目だけ戻す** `hideIndicator()` を使い、`startY` は指を離すまで保つ
- `touchstart` では、ページ上部にいるかどうかに関わらず**必ず**指の位置を記録する。記録を省くと前のジェスチャーの `startY` が残り、下までスクロールしてから上端に戻ってきた瞬間に誤判定する(同じ穴のもう一方)
- 横方向が優勢な動き(アルバムのスライダー操作など)は引っ張りとして扱わない

## 検証

実ページに実際のタッチ列を流し込み、修正前後を比較。

| タッチの動き | 修正前 | 修正後 |
|---|---|---|
| 軽いタッチ+指ぶれ(2px上→5px下) | **離して更新**(離すとリロード) | 引っ張って更新(反応なし) |
| 50px引く | 引っ張って更新 | 引っ張って更新 |
| 横スワイプ | **離して更新** | 引っ張って更新(反応なし) |
| 意図して220px引く | 離して更新 | 離して更新 |

修正前のコードでは、指を離すたびにリロードが走って無限ループになり計測が完了しなかった(症状そのもの)。

## 補足

しきい値(実距離210px)は当時この不具合を抑えるために引き上げられた値なので、真因が消えた今は下げる余地があります。今回は1点だけ直して実機の感触を見たいので据え置きました。引くのが重いと感じたら言ってください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)